### PR TITLE
feat: :heavy_plus_sign: add .claspignore and .gitignore files for project configuration

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,0 +1,29 @@
+# Ignore all files by default
+**/**
+
+# Include only necessary files for Google Apps Script
+!appsscript.json
+!**/*.gs
+!**/*.js
+!**/*.ts
+!**/*.html
+
+# Exclude specific directories even if they contain valid files
+.git/**
+node_modules/**
+.vscode/**
+.idea/**
+logs/**
+
+# Exclude configuration and sensitive files
+.env*
+.clasp.json
+*.log
+*.tmp
+*.temp
+
+# Exclude OS and editor generated files
+.DS_Store
+Thumbs.db
+*.swp
+*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Clasp configuration (contains sensitive script ID)
+.clasp.json
+
+# Node.js dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# TypeScript compiled files (if using TypeScript)
+*.js.map
+dist/
+build/
+
+# Temporary files
+*.tmp
+*.temp


### PR DESCRIPTION
This pull request updates the `.claspignore` and `.gitignore` files to improve which files are included and excluded when deploying to Google Apps Script or upload to git repository. The changes ensure that only the necessary source and configuration files are uploaded respectively for development, source, and configuration.