### PR TITLE
feat: :wrench: add jest testing

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -15,6 +15,7 @@ node_modules/**
 .idea/**
 docs/**
 scripts/**
+coverage/**
 logs/**
 
 # Exclude configuration and sensitive files

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .clasp.json
 
 # Node.js dependencies
+package-lock.json
 node_modules/
 npm-debug.log*
 yarn-debug.log*
@@ -38,6 +39,7 @@ logs/
 *.js.map
 dist/
 build/
+coverage/
 
 # Temporary files
 *.tmp

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,46 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // The test environment
+  testEnvironment: 'node',
+
+  // Test file patterns
+  testMatch: [
+    '**/test/**/*.test.js',
+    '**/test/**/*.spec.js'
+  ],
+
+  // Coverage settings
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html', 'json'],
+  
+  // Files to collect coverage from
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/**/*.test.js',
+    '!src/**/*.spec.js'
+  ],
+
+  // Setup files
+  setupFilesAfterEnv: ['<rootDir>/test/setup.js'],
+
+  // Clear mocks between tests
+  clearMocks: true,
+
+  // Reset modules between tests
+  resetModules: true,
+
+  // Verbose output
+  verbose: true,
+
+  // Transform files with custom transformer for GAS compatibility
+  transform: {
+    '^.+\\.js$': '<rootDir>/test/transformers/gas-module-transformer.js'
+  },
+
+  // Module file extensions
+  moduleFileExtensions: ['js', 'json'],
+
+  // Error on deprecated features
+  errorOnDeprecated: true
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "doc": "docs"
   },
   "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "test:ci": "jest --ci --coverage --watchAll=false",
+    "test:unit": "jest test/unit",
+    "test:verbose": "jest --verbose",
     "docs:generate": "npx documentation build src/** -f md -o docs/docs/doc.md && node scripts/clean-md.js",
     "docs:dev": "npm --prefix docs run start",
     "docs:build": "npm run docs:generate && npm --prefix docs run build",

--- a/request-example.json
+++ b/request-example.json
@@ -1,0 +1,591 @@
+{
+  "$spreadsheet": {
+    "schemaVersion": "spreadsheet-render-1.0",
+    "description": "Render instructions for converting arbitrary JSON into Google Sheets. Use JSON-Pointer with '*' and '**' wildcards in paths. More specific mappings override more general ones. If multiple mappings match a path, the mapping with higher specificity wins; if same specificity, the later mapping in the list wins.",
+    "pathSyntax": {
+      "type": "json-pointer-wildcard",
+      "notes": [
+        "Use standard JSON Pointer segments, e.g. /object/key",
+        "'*' matches any single key or array index in that position, e.g. /array/*/id",
+        "'**' matches any number of path segments recursively, e.g. /object/**/value"
+      ],
+      "examples": ["/array_of_objects/*/name", "/object_nested/**/level3"]
+    },
+    "builtInTransforms": {
+      "parseDateISO": "Parse ISO-8601 string into spreadsheet Date",
+      "preserveLeadingZeros": "Treat string as TEXT to preserve leading zeros",
+      "toString": "Convert value to string",
+      "parseJSON": "Parse a JSON string into an object/array and render according to mapping",
+      "escapeControlChars": "Replace control chars with visible escape sequences (e.g. \\u0001 -> \\u0001)",
+      "bigIntToText": "Render integers greater than `numberPrecisionThreshold` as TEXT to prevent precision loss",
+      "join": "Join array primitives with provided separator",
+      "boolToCheckbox": "Render boolean as checkbox (TRUE/FALSE)"
+    },
+    "defaults": {
+      "sheet": {
+        "defaultColumnWidth": 120,
+        "defaultRowHeight": 21,
+        "freezeHeader": true,
+        "nameTemplate": "{root}", 
+        "createSheetsForDeepTables": true
+      },
+      "cellStyle": {
+        "fontFamily": "Arial",
+        "fontSize": 10,
+        "bold": false,
+        "italic": false,
+        "wrap": true,
+        "horizontalAlign": "LEFT",
+        "verticalAlign": "MIDDLE",
+        "textColor": "#000000",
+        "backgroundColor": "#FFFFFF"
+      },
+      "headerStyle": {
+        "fontFamily": "Arial",
+        "fontSize": 10,
+        "bold": true,
+        "wrap": true,
+        "horizontalAlign": "CENTER",
+        "backgroundColor": "#F2F2F2",
+        "textColor": "#000000"
+      },
+      "numberPrecisionThreshold": 9007199254740991,
+      "typeDefaults": {
+        "string": {
+          "numberFormat": { "type": "TEXT" },
+          "cellStyle": { "wrap": true },
+          "transform": null
+        },
+        "number": {
+          "numberFormat": { "type": "NUMBER", "pattern": "#,##0.########" },
+          "cellStyle": { "horizontalAlign": "RIGHT" },
+          "transform": null
+        },
+        "boolean": {
+          "renderAs": "CHECKBOX",
+          "cellStyle": { "horizontalAlign": "CENTER" }
+        },
+        "null": {
+          "display": "",
+          "cellStyle": { "italic": true, "textColor": "#888888" }
+        },
+        "array": {
+          "render": "inline-by-default",
+          "direction": "vertical",
+          "joiner": ", "
+        },
+        "object": {
+          "render": "flatten",
+          "flattenSeparator": ".",
+          "createSubtableForArrays": true
+        }
+      },
+      "globalHeader": {
+        "show": true,
+        "labelSource": "propertyName",
+        "styleRef": "headerStyle"
+      },
+      "nullDisplay": "",
+      "emptyArrayDisplay": "[empty array]",
+      "emptyObjectDisplay": "{ }",
+      "emptyStringDisplay": ""
+    },
+    "mappings": [
+      {
+        "id": "fallback-all",
+        "path": "/**",
+        "match": "recursive-wildcard",
+        "description": "Catch-all fallback mapping: render everything as a single cell (type-aware). More specific mappings later in this list will override this.",
+        "display": {
+          "mode": "cell",
+          "valueSource": "value", 
+          "typeResolution": "runtime", 
+          "formatting": "use typeDefaults"
+        }
+      },
+
+      {
+        "id": "root-as-key-value-list",
+        "path": "/",
+        "match": "exact",
+        "description": "Render the root object as a two-column vertical list: property | rendered value. Arrays/objects are expanded according to specialized mappings.",
+        "display": {
+          "mode": "propertyList",
+          "sheetName": "Main",
+          "direction": "vertical",
+          "columns": [
+            {
+              "col": 0,
+              "header": "Property",
+              "value": { "source": "propertyName", "transform": "toString" },
+              "style": { "bold": true }
+            },
+            {
+              "col": 1,
+              "header": "Value",
+              "value": { "source": "value", "transform": null },
+              "styleRef": "cellStyle"
+            }
+          ],
+          "afterEachProperty": {
+            "insertSpacingRows": 0,
+            "expandArraysInlineIfPrimitive": true
+          }
+        },
+        "behaviorHints": {
+          "expandObjectsInlineUpToDepth": 2,
+          "ifArrayOfObjectsCreateSubTable": true
+        }
+      },
+
+      {
+        "id": "array_of_objects_table",
+        "path": "/array_of_objects",
+        "match": "exact",
+        "description": "Render this specific array-of-objects as a table with explicit columns and types.",
+        "display": {
+          "mode": "table",
+          "sheetName": "array_of_objects",
+          "header": { "show": true, "labelSource": "propertyName", "styleRef": "headerStyle" },
+          "direction": "vertical",
+          "columns": [
+            {
+              "path": "/array_of_objects/*/id",
+              "header": "id",
+              "type": "number",
+              "numberFormat": { "type": "NUMBER", "pattern": "0" },
+              "cellStyle": { "horizontalAlign": "RIGHT" },
+              "width": 60
+            },
+            {
+              "path": "/array_of_objects/*/name",
+              "header": "name",
+              "type": "string",
+              "cellStyle": { "wrap": true },
+              "width": 220
+            },
+            {
+              "path": "/array_of_objects/*/active",
+              "header": "active",
+              "type": "boolean",
+              "renderAs": "CHECKBOX",
+              "width": 70,
+              "cellStyle": { "horizontalAlign": "CENTER" }
+            },
+            {
+              "path": "/array_of_objects/*/score",
+              "header": "score",
+              "type": "number",
+              "numberFormat": { "type": "NUMBER", "pattern": "#,##0.00" },
+              "cellStyle": { "horizontalAlign": "RIGHT" },
+              "width": 90
+            }
+          ],
+          "rowOptions": { "striped": true },
+          "tableOptions": { "freezeHeader": true }
+        }
+      },
+
+      {
+        "id": "array_numbers_horizontal",
+        "path": "/array_numbers",
+        "match": "exact",
+        "description": "Render array of primitives horizontally as a single-row (one column per element).",
+        "display": {
+          "mode": "list",
+          "sheetName": "Main",
+          "direction": "horizontal",
+          "valueSource": "value",
+          "item": {
+            "type": "number",
+            "numberFormat": { "type": "NUMBER", "pattern": "0" }
+          },
+          "header": { "show": false },
+          "joiner": null
+        }
+      },
+
+      {
+        "id": "array_mixed_expand",
+        "path": "/array_mixed",
+        "match": "exact",
+        "description": "Render mixed array: primitives shown inline (comma-joined) and nested objects/arrays expanded vertically beneath the property row with indentation.",
+        "display": {
+          "mode": "composed",
+          "sheetName": "Main",
+          "direction": "vertical",
+          "primitivesRender": { "as": "joined", "separator": ", " },
+          "objectsRender": { "as": "subrows", "indent": 2 },
+          "arraysRender": { "as": "subrows", "indent": 2 },
+          "cellStyle": { "wrap": true }
+        }
+      },
+
+      {
+        "id": "array_with_nulls",
+        "path": "/array_with_nulls",
+        "match": "exact",
+        "description": "Preserve nulls as empty cells while rendering other elements vertically.",
+        "display": {
+          "mode": "list",
+          "direction": "vertical",
+          "valueSource": "value",
+          "preserveNulls": true,
+          "emptyItemDisplay": "",
+          "item": {
+            "typeResolution": "runtime",
+            "nullDisplay": ""
+          }
+        }
+      },
+
+      {
+        "id": "object_nested_flatten_and_deep_table",
+        "path": "/object_nested",
+        "match": "prefix",
+        "description": "Flatten small nested objects inline (dot-separated columns). If an inner property is an array of objects (like level3_array) create a separate sheet table for it.",
+        "display": {
+          "mode": "object",
+          "sheetName": "Main",
+          "render": "flatten",
+          "flattenSeparator": ".",
+          "maxInlineFlattenDepth": 2,
+          "arrayOfObjectsBehavior": {
+            "createSubtable": true,
+            "sheetNameTemplate": "{parent}_{property}",
+            "subtableHeaderStyleRef": "headerStyle"
+          },
+          "cellStyle": { "wrap": true }
+        }
+      },
+
+      {
+        "id": "level3_array_table",
+        "path": "/object_nested/level1/level2/level3_array",
+        "match": "exact",
+        "description": "Subtable for nested array of objects coming from object_nested.level1.level2.level3_array",
+        "display": {
+          "mode": "table",
+          "sheetName": "object_nested.level3_array",
+          "header": { "show": true, "labelSource": "propertyName" },
+          "direction": "vertical",
+          "columns": [
+            {
+              "path": "/object_nested/level1/level2/level3_array/*/a",
+              "header": "a",
+              "type": "number",
+              "numberFormat": { "type": "NUMBER", "pattern": "0" }
+            },
+            {
+              "path": "/object_nested/level1/level2/level3_array/*/b",
+              "header": "b",
+              "type": "array",
+              "displayHint": { "as": "joined", "separator": "; " }
+            }
+          ]
+        }
+      },
+
+      {
+        "id": "keys_examples_preserve_header_names",
+        "path": "/keys_examples",
+        "match": "prefix",
+        "description": "Demonstrate handling of keys with spaces, leading digits and special characters. Headers will use the original key names but a safe fallback is provided.",
+        "display": {
+          "mode": "propertyList",
+          "sheetName": "Main",
+          "direction": "vertical",
+          "columns": [
+            { "col": 0, "header": "Property", "value": { "source": "propertyName" } },
+            { "col": 1, "header": "Value", "value": { "source": "value" } }
+          ],
+          "headerSanitize": {
+            "replaceCharacters": { " ": " ", "/": "/", "\\": "\\" },
+            "fallbackPrefix": "k_"
+          }
+        }
+      },
+
+      {
+        "id": "json_text_as_string_parse",
+        "path": "/json_text_as_string",
+        "match": "exact",
+        "description": "Treat strings that contain JSON as parseable. Default: show parsed result as nested table (if object/array) and keep raw string in a note.",
+        "display": {
+          "mode": "cell+expand",
+          "sheetName": "Main",
+          "cell": {
+            "showRaw": false,
+            "transform": "parseJSON",
+            "ifParsedIsObject": { "render": "propertyListInline", "flatten": true },
+            "ifParsedIsArray": { "render": "tableIfArrayOfObjectsElseList" }
+          },
+          "noteAppendRaw": true
+        }
+      },
+
+      {
+        "id": "number_leading_zero_string",
+        "path": "/number_leading_zero_string",
+        "match": "exact",
+        "description": "Preserve leading zeros by rendering as TEXT.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "transform": "preserveLeadingZeros",
+          "cellStyle": { "horizontalAlign": "LEFT" },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "hex_literal_as_string",
+        "path": "/hex_literal_as_string",
+        "match": "exact",
+        "description": "Render hex literals as TEXT to preserve the representation.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "cellStyle": { "horizontalAlign": "LEFT" },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "date_as_string_parse",
+        "path": "/date_as_string",
+        "match": "exact",
+        "description": "Parse ISO date string into sheet Date object and format it.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "date",
+          "transform": "parseDateISO",
+          "numberFormat": { "type": "DATE_TIME", "pattern": "yyyy-mm-dd hh:mm:ss" },
+          "cellStyle": { "horizontalAlign": "CENTER" }
+        }
+      },
+
+      {
+        "id": "string_control_escape",
+        "path": "/string_control",
+        "match": "exact",
+        "description": "Show control characters as escaped sequences so they don't break sheet rendering.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "transform": "escapeControlChars",
+          "cellStyle": { "wrap": false, "backgroundColor": "#FFF7E6" },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "string_escapes_unicode",
+        "path": "/string_escapes",
+        "match": "exact",
+        "description": "Preserve newlines & tabs; enable wrap so multiline appears correctly in a cell.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "cellStyle": { "wrap": true, "verticalAlign": "TOP" },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "string_unicode",
+        "path": "/string_unicode",
+        "match": "exact",
+        "description": "Unicode strings are supported; preserve glyphs.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "cellStyle": { "wrap": true },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "number_big_as_text",
+        "path": "/number_big",
+        "match": "exact",
+        "description": "Numbers above threshold are rendered as TEXT to avoid browser JS precision errors.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "transform": "bigIntToText",
+          "cellStyle": { "horizontalAlign": "LEFT" },
+          "numberFormat": { "type": "TEXT" }
+        }
+      },
+
+      {
+        "id": "empty_values",
+        "path": "/empty_values",
+        "match": "prefix",
+        "description": "Render empty containers and empty strings with explicit placeholders defined in defaults.",
+        "display": {
+          "mode": "object",
+          "render": "flatten",
+          "emptyArrayDisplay": "[empty array]",
+          "emptyObjectDisplay": "{ }",
+          "emptyStringDisplay": "",
+          "cellStyle": { "italic": true, "textColor": "#888888" }
+        }
+      },
+
+      {
+        "id": "nested_combination_complex",
+        "path": "/nested_combination",
+        "match": "exact",
+        "description": "Arbitrary nested arrays/objects: default to optical representation — show top-level as list, and expand nested arrays/objects in subrows/subtables.",
+        "display": {
+          "mode": "complex",
+          "sheetName": "Main",
+          "direction": "vertical",
+          "primitives": { "render": "joined", "separator": ", " },
+          "objects": { "render": "subrows", "indent": 2 },
+          "arrays": { "render": "subrowsOrSheets", "createSheetIfLarge": true },
+          "cellStyle": { "wrap": true }
+        }
+      },
+
+      {
+        "id": "array_empty_and_object_empty_rendering",
+        "path": "/array_empty",
+        "match": "exact",
+        "display": { "mode": "cell", "valueSource": "value", "renderEmptyAs": "[empty array]" }
+      },
+
+      {
+        "id": "object_empty",
+        "path": "/object_empty",
+        "match": "exact",
+        "display": { "mode": "cell", "valueSource": "value", "renderEmptyAs": "{ }" }
+      },
+
+      {
+        "id": "string_empty",
+        "path": "/string_empty",
+        "match": "exact",
+        "display": { "mode": "cell", "valueSource": "value", "renderEmptyAs": "" }
+      },
+
+      {
+        "id": "boolean_defaults",
+        "path": "/**/boolean",
+        "match": "type-pattern",
+        "description": "Type-based override for booleans anywhere: show as checkbox if supported else 'TRUE/FALSE'.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "boolean",
+          "renderAs": "CHECKBOX",
+          "cellStyle": { "horizontalAlign": "CENTER" }
+        }
+      },
+
+      {
+        "id": "number_defaults",
+        "path": "/**/number",
+        "match": "type-pattern",
+        "description": "Type-based override for numbers anywhere.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "number",
+          "numberFormat": { "type": "NUMBER", "pattern": "#,##0.########" },
+          "cellStyle": { "horizontalAlign": "RIGHT" }
+        }
+      },
+
+      {
+        "id": "string_defaults",
+        "path": "/**/string",
+        "match": "type-pattern",
+        "description": "Type-based override for strings anywhere; default to TEXT with wrapping.",
+        "display": {
+          "mode": "cell",
+          "typeHint": "string",
+          "numberFormat": { "type": "TEXT" },
+          "cellStyle": { "wrap": true }
+        }
+      }
+
+    ]
+  },
+
+  "$data": {
+    "string_simple": "Hello, world",
+    "string_empty": "",
+    "string_escapes": "LLine1\nTab\tQuotes \" \\ / \b \f \r",
+    "string_unicode": "ñ, 漢字, Привет, 😄",
+    "string_control": "\u0001",
+
+    "number_integer": 42,
+    "number_zero": 0,
+    "number_negative": -123,
+    "number_fraction": 3.14159,
+    "number_exponent": 1.23e+10,
+    "number_negative_exponent": -2.5E-3,
+    "number_big": 9007199254740991,
+
+    "boolean_true": true,
+    "boolean_false": false,
+    "null_value": null,
+
+    "array_empty": [],
+    "array_numbers": [1, 2, 3],
+    "array_mixed": ["text", 10, true, null, {"k": 1}, [1, 2, 3]],
+    "array_with_nulls": [null, 1, null],
+
+    "object_empty": {},
+    "object_nested": {
+      "level1": {
+        "level2": {
+          "level3": "deep value",
+          "level3_array": [{"a": 1}, {"b": [true, false, null]}]
+        }
+      }
+    },
+
+    "keys_examples": {
+      "simple": 1,
+      "with space": "space",
+      "123start": "text_as_key",
+      "unicode_ñ": "value",
+      "special-chars_!@#": "ok"
+    },
+
+    "json_text_as_string": "{\"a\":1,\"b\":[2,3]}",
+    "number_leading_zero_string": "00123",
+    "hex_literal_as_string": "0xFF",
+    "date_as_string": "2025-08-29T18:00:00Z",
+
+    "empty_values": {"empty_array": [], "empty_object": {}, "empty_string": ""},
+
+    "nested_combination": [
+      {"k": [{"deep": null}, []]},
+      []
+    ],
+
+    "array_of_objects": [
+      {
+        "id": 1,
+        "name": "Object A",
+        "active": true,
+        "score": 9.5
+      },
+      {
+        "id": 2,
+        "name": "Object B",
+        "active": false,
+        "score": 7.3
+      },
+      {
+        "id": 3,
+        "name": "Object C",
+        "active": true,
+        "score": 8.0
+      }
+    ]
+  }
+}

--- a/test/fixtures/requestParser.fixtures.js
+++ b/test/fixtures/requestParser.fixtures.js
@@ -1,0 +1,222 @@
+/**
+ * Test fixtures for RequestParser tests
+ * Contains common test data, mock objects, and sample payloads
+ */
+
+const validSpreadsheetMetadata = {
+  schemaVersion: 'spreadsheet-render-1.0',
+  defaults: {
+    sheet: {
+      name: 'Test Sheet'
+    },
+    cellStyle: {
+      fontSize: 10
+    },
+    headerStyle: {
+      bold: true
+    },
+    typeDefaults: {
+      string: { align: 'left' },
+      number: { align: 'right' }
+    },
+    globalHeader: {
+      enabled: true
+    }
+  },
+  mappings: [
+    {
+      id: 'test-mapping-1',
+      path: '/items/*'
+    },
+    {
+      id: 'test-mapping-2', 
+      path: '/metadata/info'
+    }
+  ]
+};
+
+const validTestData = {
+  items: [
+    { id: 1, name: 'Item 1' },
+    { id: 2, name: 'Item 2' }
+  ],
+  metadata: {
+    info: 'Test metadata'
+  }
+};
+
+const validPayload = {
+  $spreadsheet: validSpreadsheetMetadata,
+  $data: validTestData
+};
+
+const validHttpEvent = {
+  postData: {
+    contents: JSON.stringify(validPayload),
+    type: 'application/json',
+    length: JSON.stringify(validPayload).length
+  },
+  parameter: {},
+  parameters: {},
+  contextPath: '',
+  contentLength: JSON.stringify(validPayload).length,
+  queryString: ''
+};
+
+const invalidHttpEvents = {
+  nullEvent: null,
+  undefinedEvent: undefined,
+  emptyObject: {},
+  noPostData: {
+    parameter: {}
+  },
+  invalidPostData: {
+    postData: 'invalid'
+  },
+  noContents: {
+    postData: {
+      type: 'application/json'
+    }
+  },
+  nonStringContents: {
+    postData: {
+      contents: { invalid: true },
+      type: 'application/json'
+    }
+  },
+  emptyContents: {
+    postData: {
+      contents: '',
+      type: 'application/json'
+    }
+  }
+};
+
+const invalidJsonStrings = {
+  malformedJson: '{ invalid json',
+  unclosedBrace: '{ "key": "value"',
+  unclosedArray: '[ "item1", "item2"',
+  invalidSyntax: '{ "key": value }',
+  emptyString: '',
+  whitespaceOnly: '   \n\t  ',
+  nullValue: 'null',
+  primitiveString: '"just a string"',
+  primitiveNumber: '42',
+  primitiveBoolean: 'true'
+};
+
+const invalidPayloads = {
+  missingSpreadsheet: {
+    $data: validTestData
+  },
+  missingData: {
+    $spreadsheet: validSpreadsheetMetadata
+  },
+  invalidSpreadsheetType: {
+    $spreadsheet: 'invalid',
+    $data: validTestData
+  },
+  nullSpreadsheet: {
+    $spreadsheet: null,
+    $data: validTestData
+  },
+  arraySpreadsheet: {
+    $spreadsheet: [],
+    $data: validTestData
+  },
+  undefinedData: {
+    $spreadsheet: validSpreadsheetMetadata,
+    $data: undefined
+  }
+};
+
+const invalidSpreadsheetMetadata = {
+  missingSchemaVersion: {
+    defaults: {},
+    mappings: []
+  },
+  invalidSchemaVersionType: {
+    schemaVersion: 123,
+    defaults: {},
+    mappings: []
+  },
+  invalidSchemaVersionFormat: {
+    schemaVersion: 'invalid-format',
+    defaults: {},
+    mappings: []
+  },
+  invalidMappingsType: {
+    schemaVersion: 'spreadsheet-render-1.0',
+    defaults: {},
+    mappings: 'invalid'
+  },
+  invalidMappingStructure: {
+    schemaVersion: 'spreadsheet-render-1.0',
+    defaults: {},
+    mappings: [
+      { id: 'valid', path: '/valid' },
+      'invalid-mapping',
+      { path: '/missing-id' },
+      { id: 'missing-path' }
+    ]
+  }
+};
+
+const edgeCasePayloads = {
+  minimalValid: {
+    $spreadsheet: {
+      schemaVersion: 'spreadsheet-render-1.0'
+    },
+    $data: {}
+  },
+  largeData: {
+    $spreadsheet: validSpreadsheetMetadata,
+    $data: {
+      items: Array(1000).fill(null).map((_, i) => ({
+        id: i,
+        name: `Item ${i}`,
+        value: Math.random()
+      }))
+    }
+  },
+  deeplyNestedData: {
+    $spreadsheet: validSpreadsheetMetadata,
+    $data: {
+      level1: {
+        level2: {
+          level3: {
+            level4: {
+              level5: {
+                value: 'deep'
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  complexMappings: {
+    $spreadsheet: {
+      ...validSpreadsheetMetadata,
+      mappings: [
+        { id: 'root', path: '/' },
+        { id: 'wildcard', path: '/items/*' },
+        { id: 'nested-wildcard', path: '/categories/*/items/*' },
+        { id: 'deep-path', path: '/data/reports/quarterly/q1/metrics' }
+      ]
+    },
+    $data: validTestData
+  }
+};
+
+module.exports = {
+  validSpreadsheetMetadata,
+  validTestData,
+  validPayload,
+  validHttpEvent,
+  invalidHttpEvents,
+  invalidJsonStrings,
+  invalidPayloads,
+  invalidSpreadsheetMetadata,
+  edgeCasePayloads
+};

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,101 @@
+/**
+ * Jest test setup file
+ * 
+ * This file is executed before each test suite and provides:
+ * - Global test utilities and helpers
+ * - Custom matchers
+ * - Mock setup and cleanup
+ */
+
+// Add custom matchers or global test utilities here
+global.testHelpers = {
+  /**
+   * Create a mock Google Apps Script HTTP event object
+   * @param {Object} options - Configuration options
+   * @param {string} options.contents - JSON string contents
+   * @param {string} options.contentType - Content type header
+   * @returns {Object} Mock HTTP event object
+   */
+  createMockHttpEvent: (options = {}) => {
+    const {
+      contents = '{}',
+      contentType = 'application/json'
+    } = options;
+
+    return {
+      postData: {
+        contents: contents,
+        type: contentType,
+        length: contents.length
+      },
+      parameter: {},
+      parameters: {},
+      contextPath: '',
+      contentLength: contents.length,
+      queryString: ''
+    };
+  },
+
+  /**
+   * Create a valid spreadsheet metadata object for testing
+   * @param {Object} overrides - Optional property overrides
+   * @returns {Object} Valid spreadsheet metadata
+   */
+  createValidSpreadsheetMetadata: (overrides = {}) => {
+    return {
+      schemaVersion: 'spreadsheet-render-1.0',
+      defaults: {
+        sheet: {},
+        cellStyle: {},
+        headerStyle: {},
+        typeDefaults: {},
+        globalHeader: {},
+        numberPrecisionThreshold: 9007199254740991,
+        nullDisplay: "",
+        emptyArrayDisplay: "[empty array]",
+        emptyObjectDisplay: "{ }",
+        emptyStringDisplay: ""
+      },
+      mappings: [],
+      pathSyntax: {
+        type: "json-pointer-wildcard"
+      },
+      ...overrides
+    };
+  },
+
+  /**
+   * Create a valid payload object for testing
+   * @param {Object} options - Configuration options
+   * @returns {Object} Valid payload object
+   */
+  createValidPayload: (options = {}) => {
+    const {
+      metadata = testHelpers.createValidSpreadsheetMetadata(),
+      data = { test: 'value' }
+    } = options;
+
+    return {
+      $spreadsheet: metadata,
+      $data: data
+    };
+  }
+};
+
+// Mock console methods in tests to avoid noise
+const originalConsole = { ...console };
+
+beforeEach(() => {
+  // Reset console mocks before each test
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  // Clean up any test-specific state
+  jest.restoreAllMocks();
+});
+
+// Export test utilities for individual test files
+module.exports = {
+  testHelpers: global.testHelpers
+};

--- a/test/transformers/gas-module-transformer.js
+++ b/test/transformers/gas-module-transformer.js
@@ -27,12 +27,12 @@ module.exports = {
 
     // Add CommonJS exports for testing
     const exportCode = `
-// Auto-generated exports for Jest testing
-if (typeof module !== 'undefined' && module.exports) {
-    module.exports = {
-        ${functionNames.join(',\n        ')}
-    };
-}`;
+    // Auto-generated exports for Jest testing
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            ${functionNames.join(',\n        ')}
+        };
+    }`;
 
     return {
       code: sourceText + exportCode

--- a/test/transformers/gas-module-transformer.js
+++ b/test/transformers/gas-module-transformer.js
@@ -28,10 +28,9 @@ module.exports = {
     // Add CommonJS exports for testing
     const exportCode = `
     // Auto-generated exports for Jest testing
+    /* istanbul ignore next */
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = {
-            ${functionNames.join(',\n        ')}
-        };
+        module.exports = { ${functionNames.join(',')} };
     }`;
 
     return {

--- a/test/transformers/gas-module-transformer.js
+++ b/test/transformers/gas-module-transformer.js
@@ -1,0 +1,74 @@
+/**
+ * Jest transformer for Google Apps Script files
+ * Automatically adds CommonJS exports for testing purposes without modifying source files
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  process(sourceText, sourcePath) {
+    // Only transform files in the src/ directory
+    if (!sourcePath.includes(path.sep + 'src' + path.sep)) {
+      return { code: sourceText };
+    }
+
+    // Skip if file already has module.exports
+    if (sourceText.includes('module.exports')) {
+      return { code: sourceText };
+    }
+
+    // Extract function names from the source
+    const functionNames = extractFunctionNames(sourceText);
+    
+    if (functionNames.length === 0) {
+      return { code: sourceText };
+    }
+
+    // Add CommonJS exports for testing
+    const exportCode = `
+// Auto-generated exports for Jest testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        ${functionNames.join(',\n        ')}
+    };
+}`;
+
+    return {
+      code: sourceText + exportCode
+    };
+  }
+};
+
+/**
+ * Extract function names from JavaScript source code
+ * @param {string} source - JavaScript source code
+ * @returns {string[]} - Array of function names
+ */
+function extractFunctionNames(source) {
+  const functionNames = [];
+  
+  // Match function declarations: function functionName(
+  const functionDeclarations = source.match(/^function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(/gm);
+  if (functionDeclarations) {
+    functionDeclarations.forEach(match => {
+      const name = match.replace(/^function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(.*/, '$1');
+      if (name && !functionNames.includes(name)) {
+        functionNames.push(name);
+      }
+    });
+  }
+
+  // Match arrow functions assigned to variables: const functionName = (
+  const arrowFunctions = source.match(/^(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=\s*(?:\([^)]*\)|[a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>/gm);
+  if (arrowFunctions) {
+    arrowFunctions.forEach(match => {
+      const name = match.replace(/^(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=.*/, '$1');
+      if (name && !functionNames.includes(name)) {
+        functionNames.push(name);
+      }
+    });
+  }
+
+  return functionNames;
+}

--- a/test/unit/RequestParser.test.js
+++ b/test/unit/RequestParser.test.js
@@ -1,0 +1,990 @@
+/**
+ * Unit tests for RequestParser.js
+ * 
+ * Tests all exported functions:
+ * - parseHttpEvent
+ * - parseJsonSafe  
+ * - extractSpreadsheetAndData
+ * - normalizeSpreadsheetMetadata
+ * 
+ * Tests cover all functions including internal helper function with comprehensive edge cases
+ */
+
+// Import functions from RequestParser.js
+const { parseHttpEvent, parseJsonSafe, extractSpreadsheetAndData, normalizeSpreadsheetMetadata } = require('../../src/RequestParser.js');
+
+// Import test fixtures
+const {
+  validSpreadsheetMetadata,
+  validTestData,
+  validPayload,
+  validHttpEvent,
+  invalidHttpEvents,
+  invalidJsonStrings,
+  invalidPayloads,
+  invalidSpreadsheetMetadata,
+  edgeCasePayloads
+} = require('../fixtures/requestParser.fixtures.js');
+
+describe('RequestParser', () => {
+  
+  describe('parseHttpEvent', () => {
+    describe('Valid HTTP events', () => {
+      test('should successfully parse a valid HTTP event', () => {
+        const result = parseHttpEvent(validHttpEvent);
+        
+        expect(result).toBeDefined();
+        expect(result.metadata).toBeDefined();
+        expect(result.data).toBeDefined();
+        expect(result.raw).toBe(validHttpEvent.postData.contents);
+        expect(result.metadata.schemaVersion).toBe('spreadsheet-render-1.0');
+        expect(result.data).toEqual(validTestData);
+      });
+
+      test('should parse HTTP event with minimal valid payload', () => {
+        const minimalEvent = {
+          postData: {
+            contents: JSON.stringify(edgeCasePayloads.minimalValid)
+          }
+        };
+        
+        const result = parseHttpEvent(minimalEvent);
+        
+        expect(result.metadata.schemaVersion).toBe('spreadsheet-render-1.0');
+        expect(result.data).toEqual({});
+      });
+
+      test('should parse HTTP event with large data payload', () => {
+        const largeEvent = {
+          postData: {
+            contents: JSON.stringify(edgeCasePayloads.largeData)
+          }
+        };
+        
+        const result = parseHttpEvent(largeEvent);
+        
+        expect(result.data.items).toHaveLength(1000);
+        expect(result.data.items[0]).toHaveProperty('id', 0);
+        expect(result.data.items[999]).toHaveProperty('id', 999);
+      });
+    });
+
+    describe('Invalid HTTP events', () => {
+      test('should throw error for null event', () => {
+        expect(() => parseHttpEvent(null)).toThrow('Invalid HTTP event: event object is null or not an object');
+      });
+
+      test('should throw error for undefined event', () => {
+        expect(() => parseHttpEvent(undefined)).toThrow('Invalid HTTP event: event object is null or not an object');
+      });
+
+      test('should throw error for non-object event', () => {
+        expect(() => parseHttpEvent('string')).toThrow();
+        expect(() => parseHttpEvent(123)).toThrow();
+        expect(() => parseHttpEvent(true)).toThrow();
+      });
+
+      test('should throw error for event without postData', () => {
+        expect(() => parseHttpEvent(invalidHttpEvents.noPostData)).toThrow('Invalid HTTP event: postData is required for POST requests');
+      });
+
+      test('should throw error for invalid postData type', () => {
+        expect(() => parseHttpEvent(invalidHttpEvents.invalidPostData)).toThrow('Invalid HTTP event: postData is required for POST requests');
+      });
+
+      test('should throw error for missing contents', () => {
+        expect(() => parseHttpEvent(invalidHttpEvents.noContents)).toThrow('Invalid HTTP event: postData.contents must be a string');
+      });
+
+      test('should throw error for non-string contents', () => {
+        expect(() => parseHttpEvent(invalidHttpEvents.nonStringContents)).toThrow('Invalid HTTP event: postData.contents must be a string');
+      });
+
+      test('should throw error for empty contents', () => {
+        expect(() => parseHttpEvent(invalidHttpEvents.emptyContents)).toThrow('Invalid HTTP event: empty request body');
+      });
+    });
+
+    describe('Error handling and validation', () => {
+      test('should include correct error path in validation errors', () => {
+        try {
+          parseHttpEvent(null);
+        } catch (error) {
+          expect(error.path).toBe('/');
+        }
+
+        try {
+          parseHttpEvent(invalidHttpEvents.noPostData);
+        } catch (error) {
+          expect(error.path).toBe('/postData');
+        }
+
+        try {
+          parseHttpEvent(invalidHttpEvents.noContents);
+        } catch (error) {
+          expect(error.path).toBe('/postData/contents');
+        }
+      });
+    });
+  });
+
+  describe('parseJsonSafe', () => {
+    describe('Valid JSON strings', () => {
+      test('should parse valid JSON object', () => {
+        const jsonString = '{"key": "value", "number": 42}';
+        const result = parseJsonSafe(jsonString);
+        
+        expect(result).toEqual({ key: 'value', number: 42 });
+      });
+
+      test('should parse valid JSON array', () => {
+        const jsonString = '[1, 2, 3, "test"]';
+        const result = parseJsonSafe(jsonString);
+        
+        expect(result).toEqual([1, 2, 3, 'test']);
+      });
+
+      test('should parse nested JSON structures', () => {
+        const jsonString = '{"nested": {"array": [1, 2], "object": {"key": "value"}}}';
+        const result = parseJsonSafe(jsonString);
+        
+        expect(result.nested.array).toEqual([1, 2]);
+        expect(result.nested.object.key).toBe('value');
+      });
+
+      test('should parse JSON with whitespace', () => {
+        const jsonString = '  \n  { "key" : "value" }  \n  ';
+        const result = parseJsonSafe(jsonString);
+        
+        expect(result).toEqual({ key: 'value' });
+      });
+    });
+
+    describe('Invalid JSON strings', () => {
+      test('should throw error for malformed JSON', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.malformedJson)).toThrow(/JSON syntax error/);
+      });
+
+      test('should throw error for unclosed brace', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.unclosedBrace)).toThrow(/JSON syntax error/);
+      });
+
+      test('should throw error for unclosed array', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.unclosedArray)).toThrow(/JSON syntax error/);
+      });
+
+      test('should throw error for invalid syntax', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.invalidSyntax)).toThrow(/JSON syntax error/);
+      });
+
+      test('should throw error for empty string', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.emptyString)).toThrow('Invalid JSON: empty or whitespace-only string');
+      });
+
+      test('should throw error for whitespace-only string', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.whitespaceOnly)).toThrow('Invalid JSON: empty or whitespace-only string');
+      });
+
+      test('should throw error for null value', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.nullValue)).toThrow('Invalid JSON: root must be an object or array');
+      });
+
+      test('should throw error for primitive values', () => {
+        expect(() => parseJsonSafe(invalidJsonStrings.primitiveString)).toThrow();
+        expect(() => parseJsonSafe(invalidJsonStrings.primitiveNumber)).toThrow();
+        expect(() => parseJsonSafe(invalidJsonStrings.primitiveBoolean)).toThrow();
+      });
+    });
+
+    describe('Input validation', () => {
+      test('should throw error for non-string input', () => {
+        expect(() => parseJsonSafe(null)).toThrow();
+        expect(() => parseJsonSafe(undefined)).toThrow();
+        expect(() => parseJsonSafe(123)).toThrow();
+        expect(() => parseJsonSafe({})).toThrow();
+        expect(() => parseJsonSafe([])).toThrow();
+      });
+    });
+
+    describe('Error details', () => {
+      test('should include line and column information in syntax errors', () => {
+        const invalidJson = '{"valid": "value", invalid}';
+        
+        try {
+          parseJsonSafe(invalidJson);
+        } catch (error) {
+          // The error format may vary between environments, so let's be flexible
+          expect(error.message).toMatch(/JSON syntax error/);
+          expect(error.details).toBeDefined();
+          expect(typeof error.details.position).toBe('number');
+        }
+      });
+
+      test('should include position information when available', () => {
+        const invalidJson = '{"valid": "value", invalid}';
+        
+        try {
+          parseJsonSafe(invalidJson);
+        } catch (error) {
+          expect(error.details.position).toBeGreaterThan(0);
+        }
+      });
+    });
+  });
+
+  describe('extractSpreadsheetAndData', () => {
+    describe('Valid payloads', () => {
+      test('should extract metadata and data from valid payload', () => {
+        const result = extractSpreadsheetAndData(validPayload);
+        
+        expect(result.metadata).toBeDefined();
+        expect(result.data).toBeDefined();
+        expect(result.metadata.schemaVersion).toBe('spreadsheet-render-1.0');
+        expect(result.data).toEqual(validTestData);
+      });
+
+      test('should handle minimal valid payload', () => {
+        const result = extractSpreadsheetAndData(edgeCasePayloads.minimalValid);
+        
+        expect(result.metadata.schemaVersion).toBe('spreadsheet-render-1.0');
+        expect(result.data).toEqual({});
+      });
+
+      test('should normalize metadata with defaults', () => {
+        const result = extractSpreadsheetAndData(edgeCasePayloads.minimalValid);
+        
+        expect(result.metadata.defaults).toBeDefined();
+        expect(result.metadata.defaults.sheet).toBeDefined();
+        expect(result.metadata.defaults.cellStyle).toBeDefined();
+        expect(result.metadata.defaults.headerStyle).toBeDefined();
+        expect(result.metadata.defaults.typeDefaults).toBeDefined();
+        expect(result.metadata.defaults.globalHeader).toBeDefined();
+      });
+
+      test('should set default values for common properties', () => {
+        const result = extractSpreadsheetAndData(edgeCasePayloads.minimalValid);
+        
+        expect(result.metadata.defaults.numberPrecisionThreshold).toBe(9007199254740991);
+        expect(result.metadata.defaults.nullDisplay).toBe('');
+        expect(result.metadata.defaults.emptyArrayDisplay).toBe('[empty array]');
+        expect(result.metadata.defaults.emptyObjectDisplay).toBe('{ }');
+        expect(result.metadata.defaults.emptyStringDisplay).toBe('');
+      });
+
+      test('should ensure pathSyntax exists with default', () => {
+        const result = extractSpreadsheetAndData(edgeCasePayloads.minimalValid);
+        
+        expect(result.metadata.pathSyntax).toBeDefined();
+        expect(result.metadata.pathSyntax.type).toBe('json-pointer-wildcard');
+      });
+
+      test('should preserve existing default values', () => {
+        const payloadWithDefaults = {
+          $spreadsheet: {
+            schemaVersion: 'spreadsheet-render-1.0',
+            defaults: {
+              nullDisplay: 'NULL',
+              emptyArrayDisplay: '[]',
+              numberPrecisionThreshold: 1000
+            }
+          },
+          $data: {}
+        };
+
+        const result = extractSpreadsheetAndData(payloadWithDefaults);
+        
+        expect(result.metadata.defaults.nullDisplay).toBe('NULL');
+        expect(result.metadata.defaults.emptyArrayDisplay).toBe('[]');
+        expect(result.metadata.defaults.numberPrecisionThreshold).toBe(1000);
+      });
+
+      test('should handle complex mappings', () => {
+        const result = extractSpreadsheetAndData(edgeCasePayloads.complexMappings);
+        
+        expect(result.metadata.mappings).toHaveLength(4);
+        expect(result.metadata.mappings[0].id).toBe('root');
+        expect(result.metadata.mappings[1].path).toBe('/items/*');
+      });
+    });
+
+    describe('Invalid payloads', () => {
+      test('should throw error for non-object input', () => {
+        expect(() => extractSpreadsheetAndData(null)).toThrow();
+        expect(() => extractSpreadsheetAndData(undefined)).toThrow();
+        expect(() => extractSpreadsheetAndData('string')).toThrow();
+        expect(() => extractSpreadsheetAndData(123)).toThrow();
+        expect(() => extractSpreadsheetAndData([])).toThrow();
+      });
+
+      test('should throw error for missing $spreadsheet', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.missingSpreadsheet)).toThrow("Missing required '$spreadsheet' metadata object");
+      });
+
+      test('should throw error for missing $data', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.missingData)).toThrow("Missing required '$data' object");
+      });
+
+      test('should throw error for invalid $spreadsheet type', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.invalidSpreadsheetType)).toThrow("Invalid '$spreadsheet': must be an object");
+      });
+
+      test('should throw error for null $spreadsheet', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.nullSpreadsheet)).toThrow("Invalid '$spreadsheet': must be an object");
+      });
+
+      test('should throw error for array $spreadsheet', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.arraySpreadsheet)).toThrow("Invalid '$spreadsheet': must be an object");
+      });
+
+      test('should throw error for undefined $data', () => {
+        expect(() => extractSpreadsheetAndData(invalidPayloads.undefinedData)).toThrow("Invalid '$data': value is undefined");
+      });
+    });
+
+    describe('Schema version validation', () => {
+      test('should throw error for missing schema version', () => {
+        expect(() => extractSpreadsheetAndData({
+          $spreadsheet: invalidSpreadsheetMetadata.missingSchemaVersion,
+          $data: {}
+        })).toThrow("Missing or invalid 'schemaVersion' in $spreadsheet metadata");
+      });
+
+      test('should throw error for invalid schema version type', () => {
+        expect(() => extractSpreadsheetAndData({
+          $spreadsheet: invalidSpreadsheetMetadata.invalidSchemaVersionType,
+          $data: {}
+        })).toThrow("Missing or invalid 'schemaVersion' in $spreadsheet metadata");
+      });
+
+      test('should throw error for invalid schema version format', () => {
+        expect(() => extractSpreadsheetAndData({
+          $spreadsheet: invalidSpreadsheetMetadata.invalidSchemaVersionFormat,
+          $data: {}
+        })).toThrow("Invalid schemaVersion format. Expected 'spreadsheet-render-X.Y'");
+      });
+
+      test('should accept valid schema version formats', () => {
+        const validVersions = [
+          'spreadsheet-render-1.0',
+          'spreadsheet-render-2.1',
+          'spreadsheet-render-10.25'
+        ];
+
+        validVersions.forEach(version => {
+          const payload = {
+            $spreadsheet: { schemaVersion: version },
+            $data: {}
+          };
+          
+          expect(() => extractSpreadsheetAndData(payload)).not.toThrow();
+        });
+      });
+    });
+
+    describe('Mappings validation', () => {
+      test('should throw error for invalid mappings type', () => {
+        expect(() => extractSpreadsheetAndData({
+          $spreadsheet: invalidSpreadsheetMetadata.invalidMappingsType,
+          $data: {}
+        })).not.toThrow(); // mappings will be normalized to empty array
+      });
+
+      test('should throw error for invalid mapping structure', () => {
+        expect(() => extractSpreadsheetAndData({
+          $spreadsheet: invalidSpreadsheetMetadata.invalidMappingStructure,
+          $data: {}
+        })).toThrow();
+      });
+
+      test('should provide detailed error messages for invalid mappings', () => {
+        try {
+          extractSpreadsheetAndData({
+            $spreadsheet: invalidSpreadsheetMetadata.invalidMappingStructure,
+            $data: {}
+          });
+        } catch (error) {
+          expect(error.message).toMatch(/Invalid mapping at index \d+/);
+          expect(error.path).toMatch(/\/\$spreadsheet\/mappings\/\d+/);
+        }
+      });
+
+      test('should handle empty mappings array', () => {
+        const payload = {
+          $spreadsheet: {
+            schemaVersion: 'spreadsheet-render-1.0',
+            mappings: []
+          },
+          $data: {}
+        };
+
+        const result = extractSpreadsheetAndData(payload);
+        expect(result.metadata.mappings).toEqual([]);
+      });
+    });
+
+    describe('Error path tracking', () => {
+      test('should include correct error paths in validation errors', () => {
+        const testCases = [
+          {
+            payload: null,
+            expectedPath: '/'
+          },
+          {
+            payload: invalidPayloads.missingSpreadsheet,
+            expectedPath: '/$spreadsheet'
+          },
+          {
+            payload: invalidPayloads.missingData,
+            expectedPath: '/$data'
+          },
+          {
+            payload: invalidPayloads.invalidSpreadsheetType,
+            expectedPath: '/$spreadsheet'
+          }
+        ];
+
+        testCases.forEach(({ payload, expectedPath }) => {
+          try {
+            extractSpreadsheetAndData(payload);
+          } catch (error) {
+            expect(error.path).toBe(expectedPath);
+          }
+        });
+      });
+    });
+  });
+
+  describe('Integration tests', () => {
+    test('should successfully parse complete valid HTTP event end-to-end', () => {
+      const result = parseHttpEvent(validHttpEvent);
+      
+      expect(result).toMatchObject({
+        metadata: expect.objectContaining({
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: expect.any(Object),
+          mappings: expect.any(Array)
+        }),
+        data: validTestData,
+        raw: validHttpEvent.postData.contents
+      });
+    });
+
+    test('should handle deeply nested data structures', () => {
+      const deepEvent = {
+        postData: {
+          contents: JSON.stringify(edgeCasePayloads.deeplyNestedData)
+        }
+      };
+
+      const result = parseHttpEvent(deepEvent);
+      expect(result.data.level1.level2.level3.level4.level5.value).toBe('deep');
+    });
+
+    test('should preserve all metadata through normalization process', () => {
+      const complexEvent = {
+        postData: {
+          contents: JSON.stringify(edgeCasePayloads.complexMappings)
+        }
+      };
+
+      const result = parseHttpEvent(complexEvent);
+      
+      expect(result.metadata.mappings).toHaveLength(4);
+      expect(result.metadata.mappings.every(m => m.id && m.path)).toBe(true);
+    });
+  });
+
+  describe('normalizeSpreadsheetMetadata', () => {
+    describe('Valid metadata normalization', () => {
+      test('should normalize minimal metadata with required defaults', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.schemaVersion).toBe('spreadsheet-render-1.0');
+        expect(result.defaults).toBeDefined();
+        expect(result.defaults.sheet).toEqual({});
+        expect(result.defaults.cellStyle).toEqual({});
+        expect(result.defaults.headerStyle).toEqual({});
+        expect(result.defaults.typeDefaults).toEqual({});
+        expect(result.defaults.globalHeader).toEqual({});
+        expect(result.mappings).toEqual([]);
+      });
+
+      test('should set default values for common properties', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.numberPrecisionThreshold).toBe(9007199254740991);
+        expect(result.defaults.nullDisplay).toBe('');
+        expect(result.defaults.emptyArrayDisplay).toBe('[empty array]');
+        expect(result.defaults.emptyObjectDisplay).toBe('{ }');
+        expect(result.defaults.emptyStringDisplay).toBe('');
+      });
+
+      test('should ensure pathSyntax exists with default type', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.pathSyntax).toBeDefined();
+        expect(result.pathSyntax.type).toBe('json-pointer-wildcard');
+      });
+
+      test('should preserve existing defaults and not overwrite them', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            sheet: { name: 'Custom Sheet' },
+            cellStyle: { fontSize: 12 },
+            headerStyle: { bold: true },
+            typeDefaults: { string: { align: 'left' } },
+            globalHeader: { enabled: false },
+            numberPrecisionThreshold: 1000,
+            nullDisplay: 'NULL',
+            emptyArrayDisplay: '[]',
+            emptyObjectDisplay: '{}',
+            emptyStringDisplay: 'EMPTY'
+          },
+          mappings: [{ id: 'test', path: '/test' }],
+          pathSyntax: { type: 'custom-syntax' }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        // Should preserve existing values
+        expect(result.defaults.sheet.name).toBe('Custom Sheet');
+        expect(result.defaults.cellStyle.fontSize).toBe(12);
+        expect(result.defaults.headerStyle.bold).toBe(true);
+        expect(result.defaults.typeDefaults.string.align).toBe('left');
+        expect(result.defaults.globalHeader.enabled).toBe(false);
+        expect(result.defaults.numberPrecisionThreshold).toBe(1000);
+        expect(result.defaults.nullDisplay).toBe('NULL');
+        expect(result.defaults.emptyArrayDisplay).toBe('[]');
+        expect(result.defaults.emptyObjectDisplay).toBe('{}');
+        expect(result.defaults.emptyStringDisplay).toBe('EMPTY');
+        expect(result.mappings).toEqual([{ id: 'test', path: '/test' }]);
+        expect(result.pathSyntax.type).toBe('custom-syntax');
+      });
+
+      test('should handle invalid defaults object by creating new one', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: 'invalid-defaults'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults).toEqual({
+          sheet: {},
+          cellStyle: {},
+          headerStyle: {},
+          typeDefaults: {},
+          globalHeader: {},
+          numberPrecisionThreshold: 9007199254740991,
+          nullDisplay: '',
+          emptyArrayDisplay: '[empty array]',
+          emptyObjectDisplay: '{ }',
+          emptyStringDisplay: ''
+        });
+      });
+
+      test('should handle null defaults object by creating new one', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: null
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults).toBeDefined();
+        expect(typeof result.defaults).toBe('object');
+      });
+
+      test('should handle invalid mappings by creating empty array', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: 'invalid-mappings'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.mappings).toEqual([]);
+      });
+
+      test('should handle null mappings by creating empty array', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: null
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.mappings).toEqual([]);
+      });
+
+      test('should handle invalid pathSyntax by creating default', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          pathSyntax: 'invalid-syntax'
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.pathSyntax).toEqual({
+          type: 'json-pointer-wildcard'
+        });
+      });
+
+      test('should handle null pathSyntax by creating default', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          pathSyntax: null
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.pathSyntax).toEqual({
+          type: 'json-pointer-wildcard'
+        });
+      });
+
+      test('should handle partial defaults object and fill missing sections', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            sheet: { name: 'Test' },
+            // Missing cellStyle, headerStyle, typeDefaults, globalHeader
+            customProperty: 'custom'
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.sheet.name).toBe('Test');
+        expect(result.defaults.customProperty).toBe('custom');
+        expect(result.defaults.cellStyle).toEqual({});
+        expect(result.defaults.headerStyle).toEqual({});
+        expect(result.defaults.typeDefaults).toEqual({});
+        expect(result.defaults.globalHeader).toEqual({});
+      });
+
+      test('should handle invalid individual default sections', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            sheet: 'invalid-sheet',
+            cellStyle: null,
+            headerStyle: 42,
+            typeDefaults: [],  // Array should remain as array since typeof [] === 'object'
+            globalHeader: 'invalid-header'
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.sheet).toEqual({});
+        expect(result.defaults.cellStyle).toEqual({});
+        expect(result.defaults.headerStyle).toEqual({});
+        expect(result.defaults.typeDefaults).toEqual([]); // Arrays pass typeof === 'object' check
+        expect(result.defaults.globalHeader).toEqual({});
+      });
+
+      test('should handle missing numberPrecisionThreshold by setting default', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            // numberPrecisionThreshold is undefined
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.numberPrecisionThreshold).toBe(9007199254740991);
+      });
+
+      test('should handle missing string display properties by setting defaults', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            // Missing nullDisplay, emptyArrayDisplay, emptyObjectDisplay, emptyStringDisplay
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.nullDisplay).toBe('');
+        expect(result.defaults.emptyArrayDisplay).toBe('[empty array]');
+        expect(result.defaults.emptyObjectDisplay).toBe('{ }');
+        expect(result.defaults.emptyStringDisplay).toBe('');
+      });
+
+      test('should handle falsy string display properties by setting defaults', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          defaults: {
+            nullDisplay: null,
+            emptyArrayDisplay: undefined,
+            emptyObjectDisplay: '',
+            emptyStringDisplay: 0
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults.nullDisplay).toBe('');
+        expect(result.defaults.emptyArrayDisplay).toBe('[empty array]');
+        expect(result.defaults.emptyObjectDisplay).toBe('{ }');
+        expect(result.defaults.emptyStringDisplay).toBe('');
+      });
+    });
+
+    describe('Mappings validation in normalization', () => {
+      test('should validate and accept valid mappings', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'mapping1', path: '/data/items' },
+            { id: 'mapping2', path: '/metadata/info' }
+          ]
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.mappings).toHaveLength(2);
+        expect(result.mappings[0]).toEqual({ id: 'mapping1', path: '/data/items' });
+        expect(result.mappings[1]).toEqual({ id: 'mapping2', path: '/metadata/info' });
+      });
+
+      test('should throw error for invalid mapping object', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'valid', path: '/valid' },
+            'invalid-mapping-string'
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 1: must be an object');
+      });
+
+      test('should throw error for null mapping', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'valid', path: '/valid' },
+            null
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 1: must be an object');
+      });
+
+      test('should throw error for mapping missing id', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { path: '/missing-id' }
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 0: missing or invalid \'id\' property');
+      });
+
+      test('should throw error for mapping with invalid id type', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 123, path: '/invalid-id-type' }
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 0: missing or invalid \'id\' property');
+      });
+
+      test('should throw error for mapping missing path', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'missing-path' }
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 0: missing or invalid \'path\' property');
+      });
+
+      test('should throw error for mapping with invalid path type', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'invalid-path', path: 42 }
+          ]
+        };
+        
+        expect(() => normalizeSpreadsheetMetadata(rawMetadata)).toThrow('Invalid mapping at index 0: missing or invalid \'path\' property');
+      });
+
+      test('should provide correct error paths for mapping validation', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: [
+            { id: 'valid', path: '/valid' },
+            { id: 'missing-path' }
+          ]
+        };
+        
+        try {
+          normalizeSpreadsheetMetadata(rawMetadata);
+        } catch (error) {
+          expect(error.path).toBe('/$spreadsheet/mappings/1/path');
+        }
+      });
+    });
+
+    describe('Complex normalization scenarios', () => {
+      test('should handle completely empty metadata object', () => {
+        const rawMetadata = {};
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.defaults).toBeDefined();
+        expect(result.mappings).toEqual([]);
+        expect(result.pathSyntax.type).toBe('json-pointer-wildcard');
+      });
+
+      test('should preserve custom properties while normalizing', () => {
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          customProperty: 'custom-value',
+          anotherCustom: { nested: 'value' },
+          defaults: {
+            customDefault: 'custom'
+          }
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.customProperty).toBe('custom-value');
+        expect(result.anotherCustom.nested).toBe('value');
+        expect(result.defaults.customDefault).toBe('custom');
+        // Should also have normalized defaults
+        expect(result.defaults.sheet).toEqual({});
+      });
+
+      test('should handle very large mappings array', () => {
+        const mappings = Array(100).fill(null).map((_, i) => ({
+          id: `mapping-${i}`,
+          path: `/data/items/${i}`
+        }));
+        
+        const rawMetadata = {
+          schemaVersion: 'spreadsheet-render-1.0',
+          mappings: mappings
+        };
+        
+        const result = normalizeSpreadsheetMetadata(rawMetadata);
+        
+        expect(result.mappings).toHaveLength(100);
+        expect(result.mappings[0].id).toBe('mapping-0');
+        expect(result.mappings[99].id).toBe('mapping-99');
+      });
+    });
+  });
+
+  describe('Edge cases and boundary conditions', () => {
+    test('should handle very large JSON payloads', () => {
+      const largeEvent = {
+        postData: {
+          contents: JSON.stringify(edgeCasePayloads.largeData)
+        }
+      };
+
+      expect(() => parseHttpEvent(largeEvent)).not.toThrow();
+      const result = parseHttpEvent(largeEvent);
+      expect(result.data.items.length).toBe(1000);
+    });
+
+    test('should handle special characters in JSON strings', () => {
+      const specialCharsPayload = {
+        $spreadsheet: { schemaVersion: 'spreadsheet-render-1.0' },
+        $data: {
+          unicode: '🚀 Unicode test ñáéíóú',
+          newlines: 'Line 1\nLine 2\nLine 3',
+          quotes: 'She said "Hello" and he replied \'Hi\'',
+          escaped: 'Backslash: \\ Forward slash: /'
+        }
+      };
+
+      const event = {
+        postData: {
+          contents: JSON.stringify(specialCharsPayload)
+        }
+      };
+
+      const result = parseHttpEvent(event);
+      expect(result.data.unicode).toBe('🚀 Unicode test ñáéíóú');
+      expect(result.data.newlines).toBe('Line 1\nLine 2\nLine 3');
+    });
+
+    test('should handle null and undefined values in data appropriately', () => {
+      const nullDataPayload = {
+        $spreadsheet: { schemaVersion: 'spreadsheet-render-1.0' },
+        $data: {
+          nullValue: null,
+          stringValue: 'test',
+          numberValue: 0,
+          booleanValue: false,
+          emptyArray: [],
+          emptyObject: {}
+        }
+      };
+
+      const event = {
+        postData: {
+          contents: JSON.stringify(nullDataPayload)
+        }
+      };
+
+      const result = parseHttpEvent(event);
+      expect(result.data.nullValue).toBeNull();
+      expect(result.data.stringValue).toBe('test');
+      expect(result.data.numberValue).toBe(0);
+      expect(result.data.booleanValue).toBe(false);
+      expect(result.data.emptyArray).toEqual([]);
+      expect(result.data.emptyObject).toEqual({});
+    });
+
+    test('should handle numeric edge cases', () => {
+      const numericPayload = {
+        $spreadsheet: { schemaVersion: 'spreadsheet-render-1.0' },
+        $data: {
+          maxSafeInteger: Number.MAX_SAFE_INTEGER,
+          minSafeInteger: Number.MIN_SAFE_INTEGER,
+          maxValue: Number.MAX_VALUE,
+          minValue: Number.MIN_VALUE,
+          infinity: 'Infinity will be stringified',
+          negativeZero: -0,
+          float: 3.14159
+        }
+      };
+
+      const event = {
+        postData: {
+          contents: JSON.stringify(numericPayload)
+        }
+      };
+
+      const result = parseHttpEvent(event);
+      expect(result.data.maxSafeInteger).toBe(Number.MAX_SAFE_INTEGER);
+      expect(result.data.negativeZero).toBe(0); // JSON.stringify converts -0 to 0
+      expect(result.data.float).toBe(3.14159);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a comprehensive setup for testing using Jest, including configuration, test utilities, and fixtures. It adds scripts for running tests, provides reusable test data and helpers, and implements a custom Jest transformer to enable testing of Google Apps Script modules by automatically exporting functions. Additionally, it updates ignore rules to exclude coverage reports from deployments.

**Testing Infrastructure and Utilities:**

* Added multiple Jest test scripts (`test`, `test:watch`, `test:coverage`, `test:ci`, `test:unit`, `test:verbose`) to the `package.json` for running and managing different types of tests.
* Introduced a global Jest test setup file `test/setup.js` that defines reusable test helpers for creating mock HTTP events, valid spreadsheet metadata, and payloads, as well as setting up and cleaning up mocks before and after tests.
* Added comprehensive test fixtures in `test/fixtures/requestParser.fixtures.js` to provide valid and invalid payloads, spreadsheet metadata, and edge cases for robust unit testing.

**Testing Google Apps Script Modules:**

* Implemented a custom Jest transformer in `test/transformers/gas-module-transformer.js` that automatically generates CommonJS exports for functions in source files, enabling direct testing of Google Apps Script code without modifying the source files.

**Project Configuration:**

* Updated `.claspignore` to exclude the `coverage/` directory from deployments, ensuring test coverage reports do not get uploaded.